### PR TITLE
fixes for Pulse Pro Hub

### DIFF
--- a/aiopulse2/const.py
+++ b/aiopulse2/const.py
@@ -53,3 +53,8 @@ TYPES = {
 }
 
 MovingAction = Enum("MovingAction", "stopped up down")
+
+# Matter vendor/product ID to model mapping
+MATTER_MODEL_MAPPING = {
+    (4938, 1): "Pulse Pro Hub",
+}


### PR DESCRIPTION
This fixes [issues](https://github.com/sillyfrog/Automate-Pulse-v2/issues/39) with this library and the Pulse Pro Hub
* JSON provided by the hub is missing a closing bracket
* JSON provided by the hub is missing model number, uses the "matter" info provided to translate into the model

Notes: I've tested this against the Pulse Pro Hub provided by The Shade Store. I'm still working on getting my dev environment setup to test the Home Assistant integration